### PR TITLE
Convert CfgPatches authors for 1.60

### DIFF
--- a/addons/backpacks/config.cpp
+++ b/addons/backpacks/config.cpp
@@ -12,6 +12,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_vests"};
+        author = ECSTRING(main,Author);
         authors[] = {"Pomigit", "BadHabitz", "Jonpas", "Rory"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/backpacks/config.cpp
+++ b/addons/backpacks/config.cpp
@@ -13,6 +13,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_vests"};
         author = ECSTRING(main,Author);
+        url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Pomigit", "BadHabitz", "Jonpas", "Rory"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/backpacks/config.cpp
+++ b/addons/backpacks/config.cpp
@@ -12,7 +12,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_vests"};
-        author[]= {"Pomigit", "BadHabitz", "Jonpas", "Rory"};
+        authors[] = {"Pomigit", "BadHabitz", "Jonpas", "Rory"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;
     };

--- a/addons/glasses/config.cpp
+++ b/addons/glasses/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas", "Pomigit"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/glasses/config.cpp
+++ b/addons/glasses/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         author = ECSTRING(main,Author);
         url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Jonpas", "Pomigit"};
-        authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
+        authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };
 };

--- a/addons/glasses/config.cpp
+++ b/addons/glasses/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
-        author[]= {"Jonpas", "Pomigit"};
+        authors[] = {"Jonpas", "Pomigit"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;
     };

--- a/addons/glasses/config.cpp
+++ b/addons/glasses/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
         author = ECSTRING(main,Author);
+        url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Jonpas", "Pomigit"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/headgear/config.cpp
+++ b/addons/headgear/config.cpp
@@ -35,6 +35,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
         author = ECSTRING(main,Author);
+        url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Pomigit", "Jonpas", "Rory"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/headgear/config.cpp
+++ b/addons/headgear/config.cpp
@@ -34,7 +34,7 @@ class CfgPatches {
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
-        author[]= {"Pomigit", "Jonpas", "Rory"};
+        authors[] = {"Pomigit", "Jonpas", "Rory"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;
     };

--- a/addons/headgear/config.cpp
+++ b/addons/headgear/config.cpp
@@ -34,6 +34,7 @@ class CfgPatches {
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"Pomigit", "Jonpas", "Rory"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/insignias/config.cpp
+++ b/addons/insignias/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         author = ECSTRING(main,Author);
         url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Jonpas", "BadHabitz", "System98"};
-        authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
+        authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };
 };

--- a/addons/insignias/config.cpp
+++ b/addons/insignias/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
         author = ECSTRING(main,Author);
+        url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Jonpas", "BadHabitz", "System98"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/insignias/config.cpp
+++ b/addons/insignias/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
-        author[]= {"Jonpas", "BadHabitz", "System98"};
+        authors[] = {"Jonpas", "BadHabitz", "System98"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;
     };

--- a/addons/insignias/config.cpp
+++ b/addons/insignias/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas", "BadHabitz", "System98"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -564,6 +564,7 @@ class CfgPatches {
             "map_vr"
         };
         author = CSTRING(Author);
+        url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {CSTRING(Author)};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -565,8 +565,8 @@ class CfgPatches {
         };
         author = CSTRING(Author);
         url = "https://github.com/Theseus-Aegis/TheseusServices";
-        authors[] = {CSTRING(Author)};
-        authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
+        authors[] = {"Jonpas"};
+        authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };
 };

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -563,7 +563,7 @@ class CfgPatches {
             "a3data",
             "map_vr"
         };
-        author[]= {CSTRING(Author)};
+        authors[] = {CSTRING(Author)};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;
     };

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -563,6 +563,7 @@ class CfgPatches {
             "a3data",
             "map_vr"
         };
+        author = CSTRING(Author);
         authors[] = {CSTRING(Author)};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/units/config.cpp
+++ b/addons/units/config.cpp
@@ -187,6 +187,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_backpacks", "tacs_headgear", "tacs_vests", "tacs_weapons"};
         author = ECSTRING(main,Author);
+        url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Pomigit", "BadHabitz", "Jonpas", "Rory"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/units/config.cpp
+++ b/addons/units/config.cpp
@@ -186,7 +186,7 @@ class CfgPatches {
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_backpacks", "tacs_headgear", "tacs_vests", "tacs_weapons"};
-        author[]= {"Pomigit", "BadHabitz", "Jonpas", "Rory"};
+        authors[] = {"Pomigit", "BadHabitz", "Jonpas", "Rory"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;
     };

--- a/addons/units/config.cpp
+++ b/addons/units/config.cpp
@@ -186,6 +186,7 @@ class CfgPatches {
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_backpacks", "tacs_headgear", "tacs_vests", "tacs_weapons"};
+        author = ECSTRING(main,Author);
         authors[] = {"Pomigit", "BadHabitz", "Jonpas", "Rory"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/vehicles/config.cpp
+++ b/addons/vehicles/config.cpp
@@ -13,7 +13,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_units"};
-        author[]= {"Pomigit", "BadHabitz", "Jonpas"};
+        authors[] = {"Pomigit", "BadHabitz", "Jonpas"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;
     };

--- a/addons/vehicles/config.cpp
+++ b/addons/vehicles/config.cpp
@@ -14,6 +14,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_units"};
         author = ECSTRING(main,Author);
+        url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Pomigit", "BadHabitz", "Jonpas"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/vehicles/config.cpp
+++ b/addons/vehicles/config.cpp
@@ -13,6 +13,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_units"};
+        author = ECSTRING(main,Author);
         authors[] = {"Pomigit", "BadHabitz", "Jonpas"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/vests/config.cpp
+++ b/addons/vests/config.cpp
@@ -24,6 +24,7 @@ class CfgPatches {
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas", "Pomigit", "BadHabitz", "Rory"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/vests/config.cpp
+++ b/addons/vests/config.cpp
@@ -27,7 +27,7 @@ class CfgPatches {
         author = ECSTRING(main,Author);
         url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Jonpas", "Pomigit", "BadHabitz", "Rory"};
-        authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
+        authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };
 };

--- a/addons/vests/config.cpp
+++ b/addons/vests/config.cpp
@@ -25,6 +25,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
         author = ECSTRING(main,Author);
+        url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Jonpas", "Pomigit", "BadHabitz", "Rory"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/vests/config.cpp
+++ b/addons/vests/config.cpp
@@ -24,7 +24,7 @@ class CfgPatches {
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
-        author[]= {"Jonpas", "Pomigit", "BadHabitz", "Rory"};
+        authors[] = {"Jonpas", "Pomigit", "BadHabitz", "Rory"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;
     };

--- a/addons/weapons/config.cpp
+++ b/addons/weapons/config.cpp
@@ -16,7 +16,7 @@ class CfgPatches {
         author = ECSTRING(main,Author);
         url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Jonpas", "Pomigit", "BadHabitz"};
-        authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
+        authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };
 };

--- a/addons/weapons/config.cpp
+++ b/addons/weapons/config.cpp
@@ -13,6 +13,7 @@ class CfgPatches {
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas", "Pomigit", "BadHabitz"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/weapons/config.cpp
+++ b/addons/weapons/config.cpp
@@ -14,6 +14,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
         author = ECSTRING(main,Author);
+        url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Jonpas", "Pomigit", "BadHabitz"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/addons/weapons/config.cpp
+++ b/addons/weapons/config.cpp
@@ -13,7 +13,7 @@ class CfgPatches {
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
-        author[]= {"Jonpas", "Pomigit", "BadHabitz"};
+        authors[] = {"Jonpas", "Pomigit", "BadHabitz"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;
     };

--- a/extras/blank/config.cpp
+++ b/extras/blank/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_main"};
-        author[]= {""};
+        author = ECSTRING(main,Author);
+        url = "https://github.com/Theseus-Aegis/TheseusServices";
+        authors[] = {""};
         authorUrl = "";
         VERSION_CONFIG;
     };

--- a/optionals/weapons_hlc/config.cpp
+++ b/optionals/weapons_hlc/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_units", "hlcweapons_ar15"};
-        author[]= {"Jonpas"};
+        authors[] = {"Jonpas"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;
     };

--- a/optionals/weapons_hlc/config.cpp
+++ b/optionals/weapons_hlc/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_units", "hlcweapons_ar15"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;

--- a/optionals/weapons_hlc/config.cpp
+++ b/optionals/weapons_hlc/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         author = ECSTRING(main,Author);
         url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Jonpas"};
-        authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
+        authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };
 };

--- a/optionals/weapons_hlc/config.cpp
+++ b/optionals/weapons_hlc/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_units", "hlcweapons_ar15"};
         author = ECSTRING(main,Author);
+        url = "https://github.com/Theseus-Aegis/TheseusServices";
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/Theseus-Aegis/TheseusServices";
         VERSION_CONFIG;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #39 
- Convert `author[]` to `authors[]`
- Add `author` entry with value `ECSTRING(main,Author)`/`CSTRING(Author)`
- Add `url` entry with value `"http://www.theseus-aegis.com/"`
- Fix missing space in front of `=` in `author[]`
- Update `blank` component as well

#### Regex used
**Converting `author[]` to `authors[]`:**
Find:
```
author\[\]= {([\s\S]*?)};
```
Replace:
```
authors\[\] = {$1};
```

**Adding `author` and `url`:**
Find:
```
class CfgPatches([\s\S]*?);([\s]*?)authors\[\]
```
Replace:
```
class CfgPatches$1;\n        author = ECSTRING\(main,Author\);$2authors\[\]
class CfgPatches$1;\n        url = "https://github.com/Theseus-Aegis/TheseusServices";$2authors\[\]
```