### PR TITLE
Use Python 3.5 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
   - release
 language: python
 python:
-- '3.4'
+- '3.5'
 before_script:
 - if [ -n "${GH_TOKEN}" ] && [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
     pip install pygithub;


### PR DESCRIPTION
**When merged this pull request will:**
- Use Python 3.5 in Travis, comes pre-installed in Trusty environment now