### PR TITLE
RHS USAF Weapons Replacement

### DIFF
--- a/optionals/weapons_rhs_usf/$PBOPREFIX$
+++ b/optionals/weapons_rhs_usf/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tacs\addons\weapons_rhs_usf

--- a/optionals/weapons_rhs_usf/CfgVehicles.hpp
+++ b/optionals/weapons_rhs_usf/CfgVehicles.hpp
@@ -1,5 +1,4 @@
 class CfgVehicles {
-
     class CLASS(Backpack_AssaultExpanded_Green);
     class CLASS(Backpack_AssaultExpanded_Green_Specialist_Filled): CLASS(Backpack_AssaultExpanded_Green) {
         scope = 1;

--- a/optionals/weapons_rhs_usf/CfgVehicles.hpp
+++ b/optionals/weapons_rhs_usf/CfgVehicles.hpp
@@ -1,0 +1,78 @@
+class CfgVehicles {
+
+    class CLASS(Backpack_AssaultExpanded_Green);
+    class CLASS(Backpack_AssaultExpanded_Green_Specialist_Filled): CLASS(Backpack_AssaultExpanded_Green) {
+        scope = 1;
+
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(rhs_200rnd_556x45_M_SAW,3);
+        };
+    };
+
+    class CLASS(Unit_Polo_CP_LS_TP_OB);
+    class CLASS(Unit_I_Bodyguard): CLASS(Unit_Polo_CP_LS_TP_OB) {
+        weapons[] = {"Throw", "Put", "tacs_rhsusf_weap_MP7A2", "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", "tacs_rhsusf_weap_MP7A2", "rhsusf_weap_glock17g4", "Binocular"};
+        magazines[] = {ITEMS_9(rhsusf_mag_40Rnd_46x30_FMJ), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
+        respawnMagazines[] = {ITEMS_9(rhsusf_mag_40Rnd_46x30_FMJ), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
+    };
+
+    class CLASS(Unit_Polo_TP_LS_TP_TB);
+    class CLASS(Unit_I_Contractor): CLASS(Unit_Polo_TP_LS_TP_TB) {
+        weapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_pmag_grip3", "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_pmag_grip3", "rhsusf_weap_glock17g4", "Binocular"};
+        magazines[] = {ITEMS_8(rhs_mag_30Rnd_556x45_Mk318_Stanag), ITEMS_3(rhsusf_mag_17Rnd_9x19_FMJ), "SmokeShell", ITEMS_4(HandGrenade)};
+        respawnMagazines[] = {ITEMS_8(rhs_mag_30Rnd_556x45_Mk318_Stanag), ITEMS_3(rhsusf_mag_17Rnd_9x19_FMJ), "SmokeShell", ITEMS_4(HandGrenade)};
+    };
+
+    class CLASS(Unit_Combat_RS_BS_GP_BB);
+    class CLASS(Unit_I_Contractor_GL): CLASS(Unit_Combat_RS_BS_GP_BB) {
+        weapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_m203", "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_m203", "rhsusf_weap_glock17g4", "Binocular"};
+        magazines[] = {ITEMS_5(rhs_mag_30Rnd_556x45_Mk318_Stanag), "1Rnd_SmokeBlue_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeRed_Grenade_shell", ITEMS_3(rhs_mag_M441_HE), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), "SmokeShell", "SmokeShellGreen", ITEMS_2(HandGrenade)};
+        respawnMagazines[] = {ITEMS_5(rhs_mag_30Rnd_556x45_Mk318_Stanag), "1Rnd_SmokeBlue_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeRed_Grenade_shell", ITEMS_3(rhs_mag_M441_HE), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), "SmokeShell", "SmokeShellGreen", ITEMS_2(HandGrenade)};
+    };
+
+    class CLASS(Unit_I_Engineer): CLASS(Unit_Polo_TP_LS_TP_TB) {
+        weapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_mstock", "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_mstock", "rhsusf_weap_glock17g4", "Binocular"};
+        magazines[] = {ITEMS_12(rhs_mag_30Rnd_556x45_Mk318_Stanag), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
+        respawnMagazines[] = {ITEMS_12(rhs_mag_30Rnd_556x45_Mk318_Stanag), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
+    };
+
+    class CLASS(Unit_I_Medic): CLASS(Unit_Combat_RS_BS_GP_BB) {
+        weapons[] = {"Throw", "Put", "tacs_rhsusf_weap_MP7A2", "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", "tacs_rhsusf_weap_MP7A2", "rhsusf_weap_glock17g4", "Binocular"};
+        magazines[] = {ITEMS_9(rhsusf_mag_40Rnd_46x30_FMJ), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), "SmokeShell", ITEMS_2(HandGrenade)};
+        respawnMagazines[] = {ITEMS_9(rhsusf_mag_40Rnd_46x30_FMJ), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), "SmokeShell", ITEMS_2(HandGrenade)};
+    };
+
+    class CLASS(Unit_I_Specialist): CLASS(Unit_Combat_RS_BS_GP_BB) {
+        weapons[] = {"Throw", "Put", "tacs_rhs_weap_m249_pip_S", "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", "tacs_rhs_weap_m249_pip_S", "rhsusf_weap_glock17g4", "Binocular"};
+        magazines[] = {"rhs_200rnd_556x45_M_SAW", ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
+        respawnMagazines[] = {"rhs_200rnd_556x45_M_SAW", ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
+    };
+
+    class CLASS(Unit_TShirt_JP_GS_LP_BB);
+    class CLASS(Unit_I_TeamLeader): CLASS(Unit_TShirt_JP_GS_LP_BB) {
+        weapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_mstock", "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_mstock", "rhsusf_weap_glock17g4", "Binocular"};
+        magazines[] = {ITEMS_11(rhs_mag_30Rnd_556x45_Mk318_Stanag), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
+        respawnMagazines[] = {ITEMS_11(rhs_mag_30Rnd_556x45_Mk318_Stanag), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
+    };
+
+    class CLASS(Unit_I_Marksman): CLASS(Unit_TShirt_JP_GS_LP_BB) {
+        weapons[] = {"Throw", "Put", "tacs_rhs_weap_sr25", "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", "tacs_rhs_weap_sr25", "rhsusf_weap_glock17g4", "Binocular"};
+        magazines[] = {ITEMS_6(rhsusf_20Rnd_762x51_m118_special_Mag), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
+        respawnMagazines[] = {ITEMS_6(rhsusf_20Rnd_762x51_m118_special_Mag), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
+    };
+
+    class CLASS(Unit_I_PilotHeli): CLASS(Unit_Combat_RS_BS_GP_BB) {
+        weapons[] = {"Throw", "Put", "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", "rhsusf_weap_glock17g4", "Binocular"};
+        magazines[] = {ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
+        respawnMagazines[] = {ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
+    };
+};

--- a/optionals/weapons_rhs_usf/CfgVehicles.hpp
+++ b/optionals/weapons_rhs_usf/CfgVehicles.hpp
@@ -10,60 +10,60 @@ class CfgVehicles {
 
     class CLASS(Unit_Polo_CP_LS_TP_OB);
     class CLASS(Unit_I_Bodyguard): CLASS(Unit_Polo_CP_LS_TP_OB) {
-        weapons[] = {"Throw", "Put", "tacs_rhsusf_weap_MP7A2", "rhsusf_weap_glock17g4", "Binocular"};
-        respawnWeapons[] = {"Throw", "Put", "tacs_rhsusf_weap_MP7A2", "rhsusf_weap_glock17g4", "Binocular"};
+        weapons[] = {"Throw", "Put", QCLASS(rhs_MP7A2_xps3_grip3), "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", QCLASS(rhs_MP7A2_xps3_grip3), "rhsusf_weap_glock17g4", "Binocular"};
         magazines[] = {ITEMS_9(rhsusf_mag_40Rnd_46x30_FMJ), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
         respawnMagazines[] = {ITEMS_9(rhsusf_mag_40Rnd_46x30_FMJ), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
     };
 
     class CLASS(Unit_Polo_TP_LS_TP_TB);
     class CLASS(Unit_I_Contractor): CLASS(Unit_Polo_TP_LS_TP_TB) {
-        weapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_pmag_grip3", "rhsusf_weap_glock17g4", "Binocular"};
-        respawnWeapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_pmag_grip3", "rhsusf_weap_glock17g4", "Binocular"};
+        weapons[] = {"Throw", "Put", QCLASS(rhs_m4_pmag_acog_grip1_m952v), "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", QCLASS(rhs_m4_pmag_acog_grip1_m952v), "rhsusf_weap_glock17g4", "Binocular"};
         magazines[] = {ITEMS_8(rhs_mag_30Rnd_556x45_Mk318_Stanag), ITEMS_3(rhsusf_mag_17Rnd_9x19_FMJ), "SmokeShell", ITEMS_4(HandGrenade)};
         respawnMagazines[] = {ITEMS_8(rhs_mag_30Rnd_556x45_Mk318_Stanag), ITEMS_3(rhsusf_mag_17Rnd_9x19_FMJ), "SmokeShell", ITEMS_4(HandGrenade)};
     };
 
     class CLASS(Unit_Combat_RS_BS_GP_BB);
     class CLASS(Unit_I_Contractor_GL): CLASS(Unit_Combat_RS_BS_GP_BB) {
-        weapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_m203", "rhsusf_weap_glock17g4", "Binocular"};
-        respawnWeapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_m203", "rhsusf_weap_glock17g4", "Binocular"};
+        weapons[] = {"Throw", "Put", QCLASS(rhs_m4_m203_eotech_m952v), "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", QCLASS(rhs_m4_m203_eotech_m952v), "rhsusf_weap_glock17g4", "Binocular"};
         magazines[] = {ITEMS_5(rhs_mag_30Rnd_556x45_Mk318_Stanag), "1Rnd_SmokeBlue_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeRed_Grenade_shell", ITEMS_3(rhs_mag_M441_HE), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), "SmokeShell", "SmokeShellGreen", ITEMS_2(HandGrenade)};
         respawnMagazines[] = {ITEMS_5(rhs_mag_30Rnd_556x45_Mk318_Stanag), "1Rnd_SmokeBlue_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeRed_Grenade_shell", ITEMS_3(rhs_mag_M441_HE), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), "SmokeShell", "SmokeShellGreen", ITEMS_2(HandGrenade)};
     };
 
     class CLASS(Unit_I_Engineer): CLASS(Unit_Polo_TP_LS_TP_TB) {
-        weapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_mstock", "rhsusf_weap_glock17g4", "Binocular"};
-        respawnWeapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_mstock", "rhsusf_weap_glock17g4", "Binocular"};
+        weapons[] = {"Throw", "Put", QCLASS(rhs_m4_mstock_xps3_grip2_m952v), "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", QCLASS(rhs_m4_mstock_xps3_grip2_m952v), "rhsusf_weap_glock17g4", "Binocular"};
         magazines[] = {ITEMS_12(rhs_mag_30Rnd_556x45_Mk318_Stanag), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
         respawnMagazines[] = {ITEMS_12(rhs_mag_30Rnd_556x45_Mk318_Stanag), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
     };
 
     class CLASS(Unit_I_Medic): CLASS(Unit_Combat_RS_BS_GP_BB) {
-        weapons[] = {"Throw", "Put", "tacs_rhsusf_weap_MP7A2", "rhsusf_weap_glock17g4", "Binocular"};
-        respawnWeapons[] = {"Throw", "Put", "tacs_rhsusf_weap_MP7A2", "rhsusf_weap_glock17g4", "Binocular"};
+        weapons[] = {"Throw", "Put", QCLASS(rhs_MP7A2_xps3_grip3), "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", QCLASS(rhs_MP7A2_xps3_grip3), "rhsusf_weap_glock17g4", "Binocular"};
         magazines[] = {ITEMS_9(rhsusf_mag_40Rnd_46x30_FMJ), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), "SmokeShell", ITEMS_2(HandGrenade)};
         respawnMagazines[] = {ITEMS_9(rhsusf_mag_40Rnd_46x30_FMJ), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), "SmokeShell", ITEMS_2(HandGrenade)};
     };
 
     class CLASS(Unit_I_Specialist): CLASS(Unit_Combat_RS_BS_GP_BB) {
-        weapons[] = {"Throw", "Put", "tacs_rhs_weap_m249_pip_S", "rhsusf_weap_glock17g4", "Binocular"};
-        respawnWeapons[] = {"Throw", "Put", "tacs_rhs_weap_m249_pip_S", "rhsusf_weap_glock17g4", "Binocular"};
+        weapons[] = {"Throw", "Put", QCLASS(rhs_m249_pip_eotech), "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", QCLASS(rhs_m249_pip_eotech), "rhsusf_weap_glock17g4", "Binocular"};
         magazines[] = {"rhs_200rnd_556x45_M_SAW", ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
         respawnMagazines[] = {"rhs_200rnd_556x45_M_SAW", ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
     };
 
     class CLASS(Unit_TShirt_JP_GS_LP_BB);
     class CLASS(Unit_I_TeamLeader): CLASS(Unit_TShirt_JP_GS_LP_BB) {
-        weapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_mstock", "rhsusf_weap_glock17g4", "Binocular"};
-        respawnWeapons[] = {"Throw", "Put", "tacs_rhs_weap_m4_mstock", "rhsusf_weap_glock17g4", "Binocular"};
+        weapons[] = {"Throw", "Put", QCLASS(rhs_m4_mstock_xps3_grip2_m952v), "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", QCLASS(rhs_m4_mstock_xps3_grip2_m952v), "rhsusf_weap_glock17g4", "Binocular"};
         magazines[] = {ITEMS_11(rhs_mag_30Rnd_556x45_Mk318_Stanag), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
         respawnMagazines[] = {ITEMS_11(rhs_mag_30Rnd_556x45_Mk318_Stanag), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
     };
 
     class CLASS(Unit_I_Marksman): CLASS(Unit_TShirt_JP_GS_LP_BB) {
-        weapons[] = {"Throw", "Put", "tacs_rhs_weap_sr25", "rhsusf_weap_glock17g4", "Binocular"};
-        respawnWeapons[] = {"Throw", "Put", "tacs_rhs_weap_sr25", "rhsusf_weap_glock17g4", "Binocular"};
+        weapons[] = {"Throw", "Put", QCLASS(rhs_sr25_m8541_harris), "rhsusf_weap_glock17g4", "Binocular"};
+        respawnWeapons[] = {"Throw", "Put", QCLASS(rhs_sr25_m8541_harris), "rhsusf_weap_glock17g4", "Binocular"};
         magazines[] = {ITEMS_6(rhsusf_20Rnd_762x51_m118_special_Mag), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
         respawnMagazines[] = {ITEMS_6(rhsusf_20Rnd_762x51_m118_special_Mag), ITEMS_2(rhsusf_mag_17Rnd_9x19_FMJ), ITEMS_2(SmokeShell), ITEMS_2(HandGrenade)};
     };

--- a/optionals/weapons_rhs_usf/CfgWeapons.hpp
+++ b/optionals/weapons_rhs_usf/CfgWeapons.hpp
@@ -1,0 +1,108 @@
+class CfgWeapons {
+    class rhsusf_weap_MP7A2_grip3;
+    class CLASS(rhsusf_weap_MP7A2): rhsusf_weap_MP7A2_grip3 {
+        class LinkedItems
+		{
+			class LinkedItemsOptic
+			{
+				slot="CowsSlot";
+				item="rhsusf_acc_eotech_xps3";
+			};
+			class LinkedItemsUnder
+			{
+				slot="UnderBarrelSlot";
+				item="rhsusf_acc_grip3";
+			};
+		};
+    };
+
+	class rhs_weap_m4_mstock;
+    class CLASS(rhs_weap_m4_mstock): rhs_weap_m4_mstock {
+		class LinkedItems
+		{
+			class LinkedItemsOptic
+			{
+				slot="CowsSlot";
+				item="rhsusf_acc_eotech_xps3";
+			};
+			class LinkedItemsUnder
+			{
+				slot="UnderBarrelSlot";
+				item="rhsusf_acc_grip2";
+			};
+			class LinkedItemsAcc
+			{
+				slot="PointerSlot";
+				item="rhsusf_acc_M952V";
+			};
+		};
+    };
+
+	class rhs_weap_m4_pmag_grip3;
+    class CLASS(rhs_weap_m4_pmag_grip3): rhs_weap_m4_pmag_grip3 {
+		class LinkedItems
+		{
+			class LinkedItemsOptic
+			{
+				slot="CowsSlot";
+				item="rhsusf_acc_ACOG_RMR";
+			};
+			class LinkedItemsUnder
+			{
+				slot="UnderBarrelSlot";
+				item="rhsusf_acc_grip1";
+			};
+			class LinkedItemsAcc
+			{
+				slot="PointerSlot";
+				item="rhsusf_acc_M952V";
+			};
+		};
+    };
+
+	class rhs_weap_m249_pip_S;
+    class CLASS(rhs_weap_m249_pip_S): rhs_weap_m249_pip_S {
+		class LinkedItems
+		{
+			class LinkedItemsOptic
+			{
+				slot="CowsSlot";
+				item="rhsusf_acc_eotech_552";
+			};
+		};
+    };
+
+	class rhs_weap_m4_m203;
+    class CLASS(rhs_weap_m4_m203): rhs_weap_m4_m203 {
+		class LinkedItems
+		{
+			class LinkedItemsOptic
+			{
+				slot="CowsSlot";
+				item="rhsusf_acc_eotech_552";
+			};
+			class LinkedItemsAcc
+			{
+				slot="PointerSlot";
+				item="rhsusf_acc_M952V";
+			};
+		};
+    };
+
+	class rhs_weap_sr25;
+    class CLASS(rhs_weap_sr25): rhs_weap_sr25 {
+		class LinkedItems
+		{
+			class LinkedItemsOptic
+			{
+				slot="CowsSlot";
+				item="rhsusf_acc_M8541";
+			};
+			class LinkedItemsUnder
+			{
+				slot="UnderBarrelSlot";
+				item="rhsusf_acc_harris_bipod";
+			};
+		};
+    };
+};

--- a/optionals/weapons_rhs_usf/CfgWeapons.hpp
+++ b/optionals/weapons_rhs_usf/CfgWeapons.hpp
@@ -2,88 +2,88 @@ class CfgWeapons {
     class rhsusf_weap_MP7A2_grip3;
     class CLASS(rhsusf_weap_MP7A2): rhsusf_weap_MP7A2_grip3 {
         class LinkedItems {
-			class LinkedItemsOptic {
-				slot="CowsSlot";
-				item="rhsusf_acc_eotech_xps3";
-			};
-			class LinkedItemsUnder {
-				slot="UnderBarrelSlot";
-				item="rhsusf_acc_grip3";
-			};
-		};
+            class LinkedItemsOptic {
+                slot="CowsSlot";
+                item="rhsusf_acc_eotech_xps3";
+            };
+            class LinkedItemsUnder {
+                slot="UnderBarrelSlot";
+                item="rhsusf_acc_grip3";
+            };
+        };
     };
 
-	class rhs_weap_m4_mstock;
+    class rhs_weap_m4_mstock;
     class CLASS(rhs_weap_m4_mstock): rhs_weap_m4_mstock {
-		class LinkedItems {
-			class LinkedItemsOptic {
-				slot="CowsSlot";
-				item="rhsusf_acc_eotech_xps3";
-			};
-			class LinkedItemsUnder {
-				slot="UnderBarrelSlot";
-				item="rhsusf_acc_grip2";
-			};
-			class LinkedItemsAcc {
-				slot="PointerSlot";
-				item="rhsusf_acc_M952V";
-			};
-		};
+        class LinkedItems {
+            class LinkedItemsOptic {
+                slot="CowsSlot";
+                item="rhsusf_acc_eotech_xps3";
+            };
+            class LinkedItemsUnder {
+                slot="UnderBarrelSlot";
+                item="rhsusf_acc_grip2";
+            };
+            class LinkedItemsAcc {
+                slot="PointerSlot";
+                item="rhsusf_acc_M952V";
+            };
+        };
     };
 
-	class rhs_weap_m4_pmag_grip3;
+    class rhs_weap_m4_pmag_grip3;
     class CLASS(rhs_weap_m4_pmag_grip3): rhs_weap_m4_pmag_grip3 {
-		class LinkedItems {
-			class LinkedItemsOptic {
-				slot="CowsSlot";
-				item="rhsusf_acc_ACOG_RMR";
-			};
-			class LinkedItemsUnder {
-				slot="UnderBarrelSlot";
-				item="rhsusf_acc_grip1";
-			};
-			class LinkedItemsAcc {
-				slot="PointerSlot";
-				item="rhsusf_acc_M952V";
-			};
-		};
+        class LinkedItems {
+            class LinkedItemsOptic {
+                slot="CowsSlot";
+                item="rhsusf_acc_ACOG_RMR";
+            };
+            class LinkedItemsUnder {
+                slot="UnderBarrelSlot";
+                item="rhsusf_acc_grip1";
+            };
+            class LinkedItemsAcc {
+                slot="PointerSlot";
+                item="rhsusf_acc_M952V";
+            };
+        };
     };
 
-	class rhs_weap_m249_pip_S;
+    class rhs_weap_m249_pip_S;
     class CLASS(rhs_weap_m249_pip_S): rhs_weap_m249_pip_S {
-		class LinkedItems {
-			class LinkedItemsOptic {
-				slot="CowsSlot";
-				item="rhsusf_acc_eotech_552";
-			};
-		};
+        class LinkedItems {
+            class LinkedItemsOptic {
+                slot="CowsSlot";
+                item="rhsusf_acc_eotech_552";
+            };
+        };
     };
 
-	class rhs_weap_m4_m203;
+    class rhs_weap_m4_m203;
     class CLASS(rhs_weap_m4_m203): rhs_weap_m4_m203 {
-		class LinkedItems {
-			class LinkedItemsOptic {
-				slot="CowsSlot";
-				item="rhsusf_acc_eotech_552";
-			};
-			class LinkedItemsAcc {
-				slot="PointerSlot";
-				item="rhsusf_acc_M952V";
-			};
-		};
+        class LinkedItems {
+            class LinkedItemsOptic {
+                slot="CowsSlot";
+                item="rhsusf_acc_eotech_552";
+            };
+            class LinkedItemsAcc {
+                slot="PointerSlot";
+                item="rhsusf_acc_M952V";
+            };
+        };
     };
 
-	class rhs_weap_sr25;
+    class rhs_weap_sr25;
     class CLASS(rhs_weap_sr25): rhs_weap_sr25 {
-		class LinkedItems {
-			class LinkedItemsOptic {
-				slot="CowsSlot";
-				item="rhsusf_acc_M8541";
-			};
-			class LinkedItemsUnder {
-				slot="UnderBarrelSlot";
-				item="rhsusf_acc_harris_bipod";
-			};
-		};
+        class LinkedItems {
+            class LinkedItemsOptic {
+                slot="CowsSlot";
+                item="rhsusf_acc_M8541";
+            };
+            class LinkedItemsUnder {
+                slot="UnderBarrelSlot";
+                item="rhsusf_acc_harris_bipod";
+            };
+        };
     };
 };

--- a/optionals/weapons_rhs_usf/CfgWeapons.hpp
+++ b/optionals/weapons_rhs_usf/CfgWeapons.hpp
@@ -1,15 +1,12 @@
 class CfgWeapons {
     class rhsusf_weap_MP7A2_grip3;
     class CLASS(rhsusf_weap_MP7A2): rhsusf_weap_MP7A2_grip3 {
-        class LinkedItems
-		{
-			class LinkedItemsOptic
-			{
+        class LinkedItems {
+			class LinkedItemsOptic {
 				slot="CowsSlot";
 				item="rhsusf_acc_eotech_xps3";
 			};
-			class LinkedItemsUnder
-			{
+			class LinkedItemsUnder {
 				slot="UnderBarrelSlot";
 				item="rhsusf_acc_grip3";
 			};
@@ -18,20 +15,16 @@ class CfgWeapons {
 
 	class rhs_weap_m4_mstock;
     class CLASS(rhs_weap_m4_mstock): rhs_weap_m4_mstock {
-		class LinkedItems
-		{
-			class LinkedItemsOptic
-			{
+		class LinkedItems {
+			class LinkedItemsOptic {
 				slot="CowsSlot";
 				item="rhsusf_acc_eotech_xps3";
 			};
-			class LinkedItemsUnder
-			{
+			class LinkedItemsUnder {
 				slot="UnderBarrelSlot";
 				item="rhsusf_acc_grip2";
 			};
-			class LinkedItemsAcc
-			{
+			class LinkedItemsAcc {
 				slot="PointerSlot";
 				item="rhsusf_acc_M952V";
 			};
@@ -40,20 +33,16 @@ class CfgWeapons {
 
 	class rhs_weap_m4_pmag_grip3;
     class CLASS(rhs_weap_m4_pmag_grip3): rhs_weap_m4_pmag_grip3 {
-		class LinkedItems
-		{
-			class LinkedItemsOptic
-			{
+		class LinkedItems {
+			class LinkedItemsOptic {
 				slot="CowsSlot";
 				item="rhsusf_acc_ACOG_RMR";
 			};
-			class LinkedItemsUnder
-			{
+			class LinkedItemsUnder {
 				slot="UnderBarrelSlot";
 				item="rhsusf_acc_grip1";
 			};
-			class LinkedItemsAcc
-			{
+			class LinkedItemsAcc {
 				slot="PointerSlot";
 				item="rhsusf_acc_M952V";
 			};
@@ -62,10 +51,8 @@ class CfgWeapons {
 
 	class rhs_weap_m249_pip_S;
     class CLASS(rhs_weap_m249_pip_S): rhs_weap_m249_pip_S {
-		class LinkedItems
-		{
-			class LinkedItemsOptic
-			{
+		class LinkedItems {
+			class LinkedItemsOptic {
 				slot="CowsSlot";
 				item="rhsusf_acc_eotech_552";
 			};
@@ -74,15 +61,12 @@ class CfgWeapons {
 
 	class rhs_weap_m4_m203;
     class CLASS(rhs_weap_m4_m203): rhs_weap_m4_m203 {
-		class LinkedItems
-		{
-			class LinkedItemsOptic
-			{
+		class LinkedItems {
+			class LinkedItemsOptic {
 				slot="CowsSlot";
 				item="rhsusf_acc_eotech_552";
 			};
-			class LinkedItemsAcc
-			{
+			class LinkedItemsAcc {
 				slot="PointerSlot";
 				item="rhsusf_acc_M952V";
 			};
@@ -91,15 +75,12 @@ class CfgWeapons {
 
 	class rhs_weap_sr25;
     class CLASS(rhs_weap_sr25): rhs_weap_sr25 {
-		class LinkedItems
-		{
-			class LinkedItemsOptic
-			{
+		class LinkedItems {
+			class LinkedItemsOptic {
 				slot="CowsSlot";
 				item="rhsusf_acc_M8541";
 			};
-			class LinkedItemsUnder
-			{
+			class LinkedItemsUnder {
 				slot="UnderBarrelSlot";
 				item="rhsusf_acc_harris_bipod";
 			};

--- a/optionals/weapons_rhs_usf/CfgWeapons.hpp
+++ b/optionals/weapons_rhs_usf/CfgWeapons.hpp
@@ -1,88 +1,88 @@
 class CfgWeapons {
     class rhsusf_weap_MP7A2_grip3;
-    class CLASS(rhsusf_weap_MP7A2): rhsusf_weap_MP7A2_grip3 {
+    class CLASS(rhs_MP7A2_xps3_grip3): rhsusf_weap_MP7A2_grip3 {
         class LinkedItems {
             class LinkedItemsOptic {
-                slot="CowsSlot";
-                item="rhsusf_acc_eotech_xps3";
+                slot = "CowsSlot";
+                item = "rhsusf_acc_eotech_xps3";
             };
             class LinkedItemsUnder {
-                slot="UnderBarrelSlot";
-                item="rhsusf_acc_grip3";
+                slot = "UnderBarrelSlot";
+                item = "rhsusf_acc_grip3";
             };
         };
     };
 
     class rhs_weap_m4_mstock;
-    class CLASS(rhs_weap_m4_mstock): rhs_weap_m4_mstock {
+    class CLASS(rhs_m4_mstock_xps3_grip2_m952v): rhs_weap_m4_mstock {
         class LinkedItems {
             class LinkedItemsOptic {
-                slot="CowsSlot";
-                item="rhsusf_acc_eotech_xps3";
+                slot = "CowsSlot";
+                item = "rhsusf_acc_eotech_xps3";
             };
             class LinkedItemsUnder {
-                slot="UnderBarrelSlot";
-                item="rhsusf_acc_grip2";
+                slot = "UnderBarrelSlot";
+                item = "rhsusf_acc_grip2";
             };
             class LinkedItemsAcc {
-                slot="PointerSlot";
-                item="rhsusf_acc_M952V";
+                slot = "PointerSlot";
+                item = "rhsusf_acc_M952V";
             };
         };
     };
 
     class rhs_weap_m4_pmag_grip3;
-    class CLASS(rhs_weap_m4_pmag_grip3): rhs_weap_m4_pmag_grip3 {
+    class CLASS(rhs_m4_pmag_acog_grip1_m952v): rhs_weap_m4_pmag_grip3 {
         class LinkedItems {
             class LinkedItemsOptic {
-                slot="CowsSlot";
-                item="rhsusf_acc_ACOG_RMR";
+                slot = "CowsSlot";
+                item = "rhsusf_acc_ACOG_RMR";
             };
             class LinkedItemsUnder {
-                slot="UnderBarrelSlot";
-                item="rhsusf_acc_grip1";
+                slot = "UnderBarrelSlot";
+                item = "rhsusf_acc_grip1";
             };
             class LinkedItemsAcc {
-                slot="PointerSlot";
-                item="rhsusf_acc_M952V";
+                slot = "PointerSlot";
+                item = "rhsusf_acc_M952V";
             };
         };
     };
 
     class rhs_weap_m249_pip_S;
-    class CLASS(rhs_weap_m249_pip_S): rhs_weap_m249_pip_S {
+    class CLASS(rhs_m249_pip_eotech): rhs_weap_m249_pip_S {
         class LinkedItems {
             class LinkedItemsOptic {
-                slot="CowsSlot";
-                item="rhsusf_acc_eotech_552";
+                slot = "CowsSlot";
+                item = "rhsusf_acc_eotech_552";
             };
         };
     };
 
     class rhs_weap_m4_m203;
-    class CLASS(rhs_weap_m4_m203): rhs_weap_m4_m203 {
+    class CLASS(rhs_m4_m203_eotech_m952v): rhs_weap_m4_m203 {
         class LinkedItems {
             class LinkedItemsOptic {
-                slot="CowsSlot";
-                item="rhsusf_acc_eotech_552";
+                slot = "CowsSlot";
+                item = "rhsusf_acc_eotech_552";
             };
             class LinkedItemsAcc {
-                slot="PointerSlot";
-                item="rhsusf_acc_M952V";
+                slot = "PointerSlot";
+                item = "rhsusf_acc_M952V";
             };
         };
     };
 
     class rhs_weap_sr25;
-    class CLASS(rhs_weap_sr25): rhs_weap_sr25 {
+    class CLASS(rhs_sr25_m8541_harris): rhs_weap_sr25 {
         class LinkedItems {
             class LinkedItemsOptic {
-                slot="CowsSlot";
-                item="rhsusf_acc_M8541";
+                slot = "CowsSlot";
+                item = "rhsusf_acc_M8541";
             };
             class LinkedItemsUnder {
-                slot="UnderBarrelSlot";
-                item="rhsusf_acc_harris_bipod";
+                slot = "UnderBarrelSlot";
+                item = "rhsusf_acc_harris_bipod";
             };
         };
     };

--- a/optionals/weapons_rhs_usf/README.md
+++ b/optionals/weapons_rhs_usf/README.md
@@ -1,0 +1,8 @@
+# About
+
+Replaces unit's vanilla weapons with RHS USAF weapons.
+
+### Authors
+
+- [Jonpas](http://github.com/jonpas)
+- [JoramD](http://github.com/JoramD0)

--- a/optionals/weapons_rhs_usf/README.md
+++ b/optionals/weapons_rhs_usf/README.md
@@ -4,5 +4,5 @@ Replaces unit's vanilla weapons with RHS USAF weapons.
 
 ### Authors
 
-- [Jonpas](http://github.com/jonpas)
 - [JoramD](http://github.com/JoramD0)
+- VastGameMaster

--- a/optionals/weapons_rhs_usf/config.cpp
+++ b/optionals/weapons_rhs_usf/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacs_units", "rhsusf_weapons", "rhsusf_weapons2", "rhsusf_weapons3"};
         author = ECSTRING(main,Author);
-        authors[] = {"Jonpas", "JoramD"};
+        authors[] = {"JoramD", "VastGameMaster"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
     };

--- a/optionals/weapons_rhs_usf/config.cpp
+++ b/optionals/weapons_rhs_usf/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tacs_units", "rhsusf_weapons", "rhsusf_weapons2", "rhsusf_weapons3"};
+        author = ECSTRING(main,Author);
+        authors[] = {"Jonpas", "JoramD"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"
+#include "CfgVehicles.hpp"

--- a/optionals/weapons_rhs_usf/config.cpp
+++ b/optionals/weapons_rhs_usf/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"tacs_units", "rhsusf_weapons", "rhsusf_weapons2", "rhsusf_weapons3"};
+        requiredAddons[] = {"tacs_units", "rhsusf_c_weapons"};
         author = ECSTRING(main,Author);
         authors[] = {"JoramD", "VastGameMaster"};
         url = ECSTRING(main,URL);

--- a/optionals/weapons_rhs_usf/script_component.hpp
+++ b/optionals/weapons_rhs_usf/script_component.hpp
@@ -1,0 +1,13 @@
+#define COMPONENT weapons_rhs_usf
+#define COMPONENT_BEAUTIFIED RHS USAF Weapons Replacement
+#include "\x\tacs\addons\main\script_mod.hpp"
+
+#ifdef DEBUG_ENABLED_WEAPONS_RHS_USF
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_WEAPONS_RHS_USF
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_WEAPONS_RHS_USF
+#endif
+
+#include "\x\tacs\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Add RHS USAF Weapons Replacement

Changes from file in #73 : 
- Restructured similar to weapons_hlc
- Magazine amounts same as default
- Grenades/smokes left default (exception: grenadier 1Rnd grenades are rhs)
- Changed pre-loaded specialist backpack to have rhs ammo belt

closes #73