### PR TITLE
Fix error line numbers being wrong

### DIFF
--- a/extras/blank/functions/fnc_empty.sqf
+++ b/extras/blank/functions/fnc_empty.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: [Name of Author(s)]
  * [Description]
@@ -14,6 +15,5 @@
  *
  * Public: [Yes/No]
  */
-#include "script_component.hpp"
 
 diag_log text format["This is here as an example!!!"];


### PR DESCRIPTION
**When merged this pull request will:**
- Do the same as https://github.com/acemod/ACE3/pull/6407 and https://github.com/CBATeam/CBA_A3/pull/937
- Only blank function exists, so maybe slightly redundant PR! :laughing: 

Regex used:
```bash
find . -name '*.sqf' -type f -exec perl -0777 -pi -e 's/(.+)\#include\s\"script_component\.hpp\"\n/\#include \"script_component\.hpp\"\n\1/gs' -- {} +
```