### PR TITLE
Remove custom vests ItemInfo (cargo size and mass)

### DIFF
--- a/addons/vests/CfgWeapons.hpp
+++ b/addons/vests/CfgWeapons.hpp
@@ -1,54 +1,16 @@
 class CfgWeapons {
-    class Vest_NoCamo_Base;
-
-    #define MACRO_PLATECARRIERFULL_COMMON \
-        dlc = QUOTE(PREFIX); \
-        scope = 2; \
-        hiddenSelections[] = {"camo"}; \
-        class ItemInfo: ItemInfo { \
-            containerClass = "Supply140"; \
-            mass = 110; \
-            hiddenSelections[] = {"camo"}; \
-            class HitpointsProtectionInfo { \
-                class Chest { \
-                    hitpointName = "HitChest"; \
-                    armor = 22.5; \
-                    passThrough = 0.5; \
-                }; \
-                class Diaphragm { \
-                    hitpointName = "HitDiaphragm"; \
-                    armor = 22.5; \
-                    passThrough = 0.5; \
-                }; \
-                class Abdomen { \
-                    hitpointName = "HitAbdomen"; \
-                    armor = 22.5; \
-                    passThrough = 0.5; \
-                }; \
-                class Pelvis { \
-                    hitpointName = "HitPelvis"; \
-                    armor = 22.5; \
-                    passThrough = 0.5; \
-                }; \
-                class Body { \
-                    hitpointName = "HitBody"; \
-                    passThrough = 0.5; \
-                }; \
-            }; \
-        };
-
-    class V_PlateCarrierIA1_dgtl: Vest_NoCamo_Base {
-        class ItemInfo;
-    };
+    class V_PlateCarrierIA1_dgtl;
     class CLASS(Vest_PlateCarrierFull_Black): V_PlateCarrierIA1_dgtl {
-        MACRO_PLATECARRIERFULL_COMMON
+        dlc = QUOTE(PREFIX);
+        scope = 2;
         author = "Pomigit, Jonpas";
         displayName = CSTRING(Vest_PlateCarrierFull_Black);
         picture = QPATHTOF(UI\vest_platecarrierfull_black_ca.paa);
         hiddenSelectionsTextures[] = {QPATHTOF(data\vest_platecarrierfull_black_co.paa)};
     };
     class CLASS(Vest_PlateCarrierFull_Green): V_PlateCarrierIA1_dgtl {
-        MACRO_PLATECARRIERFULL_COMMON
+        dlc = QUOTE(PREFIX);
+        scope = 2;
         author = "Pomigit, Jonpas";
         displayName = CSTRING(Vest_PlateCarrierFull_Green);
         picture = QPATHTOF(UI\vest_platecarrierfull_green_ca.paa);
@@ -56,75 +18,50 @@ class CfgWeapons {
     };
 
 
-    #define MACRO_PLATECARRIER_COMMON \
-        dlc = QUOTE(PREFIX); \
-        scope = 2; \
-        hiddenSelections[] = {"camo"}; \
-        class ItemInfo: ItemInfo { \
-            hiddenSelections[] = {"camo"}; \
-            class HitpointsProtectionInfo { \
-                class Chest { \
-                    hitpointName = "HitChest"; \
-                    armor = 20; \
-                    passThrough = 0.5; \
-                }; \
-                class Diaphragm { \
-                    hitpointName = "HitDiaphragm"; \
-                    armor = 20; \
-                    passThrough = 0.5; \
-                }; \
-                class Abdomen { \
-                    hitpointName = "HitAbdomen"; \
-                    armor = 20; \
-                    passThrough = 0.5; \
-                }; \
-                class Body { \
-                    hitpointName = "HitBody"; \
-                    passThrough = 0.5; \
-                }; \
-            }; \
-        };
-
-    class V_PlateCarrier1_rgr: Vest_NoCamo_Base {
-        class ItemInfo;
-    };
+    class V_PlateCarrier1_rgr;
     class CLASS(Vest_PlateCarrier_Black): V_PlateCarrier1_rgr {
-        MACRO_PLATECARRIER_COMMON
+        dlc = QUOTE(PREFIX);
+        scope = 2;
         author = "Pomigit, Jonpas, Rory";
         displayName = CSTRING(Vest_PlateCarrier_Black);
         picture = QPATHTOF(UI\vest_platecarrier_black_ca.paa);
         hiddenSelectionsTextures[] = {QPATHTOF(data\vest_platecarrier_black_co.paa)};
     };
     class CLASS(Vest_PlateCarrier_Green): V_PlateCarrier1_rgr {
-        MACRO_PLATECARRIER_COMMON
+        dlc = QUOTE(PREFIX);
+        scope = 2;
         author = "Pomigit, Jonpas, Rory";
         displayName = CSTRING(Vest_PlateCarrier_Green);
         picture = QPATHTOF(UI\vest_platecarrier_green_ca.paa);
         hiddenSelectionsTextures[] = {QPATHTOF(data\vest_platecarrier_green_co.paa)};
     };
     class CLASS(Vest_PlateCarrier_Coyote): V_PlateCarrier1_rgr {
-        MACRO_PLATECARRIER_COMMON
+        dlc = QUOTE(PREFIX);
+        scope = 2;
         author = "Pomigit, Jonpas, Rory";
         displayName = CSTRING(Vest_PlateCarrier_Coyote);
         picture = QPATHTOF(UI\vest_platecarrier_coyote_ca.paa);
         hiddenSelectionsTextures[] = {QPATHTOF(data\vest_platecarrier_coyote_co.paa)};
     };
     class CLASS(Vest_PlateCarrier_Khaki): V_PlateCarrier1_rgr {
-        MACRO_PLATECARRIER_COMMON
+        dlc = QUOTE(PREFIX);
+        scope = 2;
         author = "Pomigit, Jonpas, Rory";
         displayName = CSTRING(Vest_PlateCarrier_Khaki);
         picture = QPATHTOF(UI\vest_platecarrier_khaki_ca.paa);
         hiddenSelectionsTextures[] = {QPATHTOF(data\vest_platecarrier_khaki_co.paa)};
     };
     class CLASS(Vest_PlateCarrier_MARPAT): V_PlateCarrier1_rgr {
-        MACRO_PLATECARRIER_COMMON
+        dlc = QUOTE(PREFIX);
+        scope = 2;
         author = "Pomigit, Jonpas, Rory";
         displayName = CSTRING(Vest_PlateCarrier_MARPAT);
         picture = QPATHTOF(UI\vest_platecarrier_marpat_ca.paa);
         hiddenSelectionsTextures[] = {QPATHTOF(data\vest_platecarrier_marpat_co.paa)};
     };
     class CLASS(Vest_PlateCarrier_White): V_PlateCarrier1_rgr {
-        MACRO_PLATECARRIER_COMMON
+        dlc = QUOTE(PREFIX);
+        scope = 2;
         author = "Pomigit, Rory, Kresky";
         displayName = CSTRING(Vest_PlateCarrier_White);
         picture = QPATHTOF(UI\vest_platecarrier_white_ca.paa);
@@ -132,34 +69,34 @@ class CfgWeapons {
     };
 
 
-    #define MACRO_PLATECARRIERHEAVY_COMMON \
-        dlc = QUOTE(PREFIX); \
-        scope = 2; \
-
     class V_PlateCarrierGL_rgr;
     class CLASS(Vest_PlateCarrierHeavy_Black): V_PlateCarrierGL_rgr {
-        MACRO_PLATECARRIERHEAVY_COMMON
+        dlc = QUOTE(PREFIX);
+        scope = 2;
         author = "Kresky";
         displayName = CSTRING(Vest_PlateCarrierHeavy_Black);
         picture = QPATHTOF(UI\vest_PlateCarrierHeavy_black_ca.paa);
         hiddenSelectionsTextures[] = {QPATHTOF(data\vest_PlateCarrierHeavy_black_co.paa)};
     };
     class CLASS(Vest_PlateCarrierHeavy_Coyote): V_PlateCarrierGL_rgr {
-        MACRO_PLATECARRIERHEAVY_COMMON
+        dlc = QUOTE(PREFIX);
+        scope = 2;
         author = "Kresky";
         displayName = CSTRING(Vest_PlateCarrierHeavy_Coyote);
         picture = QPATHTOF(UI\vest_PlateCarrierHeavy_coyote_ca.paa);
         hiddenSelectionsTextures[] = {QPATHTOF(data\vest_PlateCarrierHeavy_coyote_co.paa)};
     };
     class CLASS(Vest_PlateCarrierHeavy_Green): V_PlateCarrierGL_rgr {
-        MACRO_PLATECARRIERHEAVY_COMMON
+        dlc = QUOTE(PREFIX);
+        scope = 2;
         author = "Kresky";
         displayName = CSTRING(Vest_PlateCarrierHeavy_Green);
         picture = QPATHTOF(UI\vest_PlateCarrierHeavy_green_ca.paa);
         hiddenSelectionsTextures[] = {QPATHTOF(data\vest_PlateCarrierHeavy_green_co.paa)};
     };
     class CLASS(Vest_PlateCarrierHeavy_White): V_PlateCarrierGL_rgr {
-        MACRO_PLATECARRIERHEAVY_COMMON
+        dlc = QUOTE(PREFIX);
+        scope = 2;
         author = "Kresky";
         displayName = CSTRING(Vest_PlateCarrierHeavy_White);
         picture = QPATHTOF(UI\vest_PlateCarrierHeavy_white_ca.paa);
@@ -167,10 +104,7 @@ class CfgWeapons {
     };
 
 
-    class Vest_Camo_Base;
-    class V_TacVest_khk: Vest_Camo_Base {
-        class ItemInfo;
-    };
+    class V_TacVest_khk;
     class CLASS(Vest_Tactical_DarkBlack): V_TacVest_khk {
         dlc = QUOTE(PREFIX);
         scope = 2;


### PR DESCRIPTION
**When merged this pull request will:**
- Remove custom size and mass from vest retextures (remnant from PG Services)
- Cleanup vests config