### PR TITLE
Arcadian - Fix UserActions on Armed Arcadian

### DIFF
--- a/addons/arcadian/base/baseclass.hpp
+++ b/addons/arcadian/base/baseclass.hpp
@@ -59,11 +59,11 @@ class CLASS(Arcadian_Base): Car_F {
     #include "config_simpleobject.hpp"
     #include "config_sound.hpp"
     #include "config_turret_rear.hpp"
-    #include "config_useractions.hpp"
 };
 
 class CLASS(Arcadian_Unarmed_Base): CLASS(Arcadian_Base) {
     #include "config_texturesources_unarmed.hpp"
+    #include "config_useractions.hpp"
 
     class EventHandlers: EventHandlers {
         init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle;};";

--- a/addons/arcadian/script_component.hpp
+++ b/addons/arcadian/script_component.hpp
@@ -19,7 +19,7 @@
             "a3\data_f\glass_veh_armored_damage.rvmat", \
             "a3\data_f\glass_veh_armored_damage.rvmat" \
         }; \
-    }
+    };
 
 #define MACRO_ARCADIAN_ARMED_DAMAGE \
     class Damage { \
@@ -35,7 +35,7 @@
             "a3\data_f\glass_veh_armored_damage.rvmat", \
             "a3\data_f\glass_veh_armored_damage.rvmat" \
         }; \
-    }
+    };
 
 #define MACRO_INDEPENDENT_VEHICLE \
     scope = 2; \


### PR DESCRIPTION
- Rear window action was showing from Passenger 1 of the armed Arcadian since "Rear Gunner" doesn't exist when an actual gunner is present. Moved to Unarmed base.
- Readded semicolons to macro because it wouldn't build.