### PR TITLE
Arcadian - Fix Turret Elevation/Depression

### DIFF
--- a/addons/arcadian/base/config_turret_gatling.hpp
+++ b/addons/arcadian/base/config_turret_gatling.hpp
@@ -4,7 +4,7 @@ class Turrets: Turrets {
         gun = "mainGun";
         viewGunnerInExternal = 1;
         minElev = -10;
-        maxElev = 10;
+        maxElev = 20;
         initElev = 0;
         soundServo[] = {"a3\sounds_f\dummysound", 0, 1};
         stabilizedInAxes = 0; // StabilizedInAxesNone

--- a/addons/arcadian/data/model.cfg
+++ b/addons/arcadian/data/model.cfg
@@ -677,7 +677,7 @@ class CfgModels {
             class MainGun: MainTurret {
                 source = "mainGun";
                 selection = "otocHlavenSUV";
-                axis = "osaHlvane";
+                axis = "gunHolder_axis";
             };
             class MachineGun: Rotation {
                 selection = "gatling_1";


### PR DESCRIPTION
- Turret now moves smoothly up and down as opposed to thrusting in and out.
- Elevation/Depression angles are now far better.