### PR TITLE
Arcadian - Fix Rogue Water temp gauge

### DIFF
--- a/addons/arcadian/data/model.cfg
+++ b/addons/arcadian/data/model.cfg
@@ -565,7 +565,7 @@ class CfgModels {
             class IndicatorWaterTemp: Rotation {
                 source = "rpm";
                 selection = "waterTemp";
-                axis = "waterTempt_axis";
+                axis = "waterTemp_axis";
                 memory = 1;
                 maxValue = 1;
                 angle1 = "rad 80";


### PR DESCRIPTION
When turning the engine on, the water temp indicator just decided to live by Seat 4 in the corner. Fixed the typo causing it.