### PR TITLE
Arcadian - Set default ACE patient seats to rear seats

### DIFF
--- a/addons/arcadian/base/baseclass.hpp
+++ b/addons/arcadian/base/baseclass.hpp
@@ -83,6 +83,7 @@ class CLASS(Arcadian_Armed_Base): CLASS(Arcadian_Base) {
     #include "config_animationsources_armed.hpp"
     #include "config_texturesources_armed.hpp"
     #include "config_turret_gatling.hpp"
+    #include "config_ace_armed.hpp"
     #include "config_acre_armed.hpp"
 
     animationList[] = {

--- a/addons/arcadian/base/config_ace.hpp
+++ b/addons/arcadian/base/config_ace.hpp
@@ -4,3 +4,6 @@ class ACE_Actions: ACE_Actions {
         selection = "ace_interact_point";
     };
 };
+
+// Cargo index is different for unarmed
+ace_medical_treatment_patientSeats[] = {4, 5};

--- a/addons/arcadian/base/config_ace_armed.hpp
+++ b/addons/arcadian/base/config_ace_armed.hpp
@@ -1,0 +1,2 @@
+// Cargo index is different for armed.
+ace_medical_treatment_patientSeats[] = {1,2};

--- a/addons/arcadian/base/config_ace_armed.hpp
+++ b/addons/arcadian/base/config_ace_armed.hpp
@@ -1,2 +1,2 @@
-// Cargo index is different for armed.
-ace_medical_treatment_patientSeats[] = {1,2};
+// Cargo index is different for armed
+ace_medical_treatment_patientSeats[] = {1, 2};


### PR DESCRIPTION
- Sets the rear seats to be the default place for unconscious units to be loaded. (Split Armed/Unarmed because Cargo index is different)
- Doesn't use the rear (window) seat or gunner position unless completely out of seats i guess?