### PR TITLE
Arcadian - Increase headlights flare distance

### DIFF
--- a/addons/arcadian/base/config_reflectors.hpp
+++ b/addons/arcadian/base/config_reflectors.hpp
@@ -8,19 +8,19 @@ class Reflectors {
         selection = "Light_L";
         size = 1;
         innerAngle = 30;
-        outerAngle = 179;
+        outerAngle = 180;
         coneFadeCoef = 5;
-        intensity = 10;
+        intensity = 50;
         useFlare = 1;
         dayLight = 0;
-        flareSize = 2;
-        flareMaxDistance = 90;
+        flareSize = 4;
+        flareMaxDistance = 600;
         class Attenuation {
             start = 1;
             constant = 0;
             linear = 0;
             quadratic = 0.25;
-            hardLimitStart = 10;
+            hardLimitStart = 50;
             hardLimitEnd = 120;
         };
     };


### PR DESCRIPTION
- Noticed a few weeks ago, headlights are useless as the driver but because of the way Arma works they're amazingly better for passengers. Slight improvement really but it's something.

`flareMaxDistance = 600;` seems like an excessive change but 600 is actually default so ours was way lower.