### PR TITLE
Arcadian - Switch magazine loadout to yellow tracer

### DIFF
--- a/addons/arcadian/CfgWeapons.hpp
+++ b/addons/arcadian/CfgWeapons.hpp
@@ -2,5 +2,6 @@ class CfgWeapons {
     class LMG_Minigun_Transport;
     class CLASS(LMG_Minigun_SUV): LMG_Minigun_Transport {
         displayName = "M134 Minigun 6.5mm";
+        magazines[] = {"2000Rnd_65x39_Belt_Tracer_Yellow", "1000Rnd_65x39_Belt_Tracer_Yellow"};
     };
 };

--- a/addons/arcadian/base/config_turret_gatling.hpp
+++ b/addons/arcadian/base/config_turret_gatling.hpp
@@ -14,7 +14,7 @@ class Turrets: Turrets {
         weapons[] = {QCLASS(LMG_Minigun_SUV)};
         maxHorizontalRotSpeed = 2;
         maxVerticalRotSpeed = 2;
-        magazines[] = {"2000Rnd_65x39_Belt_Tracer_Green", "1000Rnd_65x39_Belt_Tracer_Red"};
+        magazines[] = {"2000Rnd_65x39_Belt_Tracer_Yellow", "1000Rnd_65x39_Belt_Tracer_Yellow"};
         gunnerRightHandAnimName = "OtocHlavenSUV";
         gunnerLeftHandAnimName = "OtocHlavenSUV";
         animationSourceHatch = "close_cover_source";


### PR DESCRIPTION
Keeps the same 1x 1000Rnd & 1x 2000Rnd but now it's _yellow_.