### PR TITLE
Vehicles - Fix Texture sync for spawned vehicles

### DIFF
--- a/addons/arcadian/base/baseclass.hpp
+++ b/addons/arcadian/base/baseclass.hpp
@@ -66,7 +66,7 @@ class CLASS(Arcadian_Unarmed_Base): CLASS(Arcadian_Base) {
     #include "config_useractions.hpp"
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle;};";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
         killed = "if (local (_this select 0)) then { _this select 0 setPlateNumber '';};";
     };
 };
@@ -91,7 +91,7 @@ class CLASS(Arcadian_Armed_Base): CLASS(Arcadian_Base) {
     };
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle;};";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
         killed = "if (local (_this select 0)) then { _this select 0 setPlateNumber '';};";
     };
 };

--- a/addons/vehicles/vehicles/hemtt.hpp
+++ b/addons/vehicles/vehicles/hemtt.hpp
@@ -21,7 +21,7 @@ class CLASS(HEMTT_Base): B_Truck_01_transport_F {
     };
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
     };
 };
 
@@ -74,7 +74,7 @@ class CLASS(HEMTT_Repair_Base): B_Truck_01_Repair_F {
     };
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
     };
 };
 
@@ -126,7 +126,7 @@ class CLASS(HEMTT_Ammo_Base): B_Truck_01_ammo_F {
     };
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
     };
 };
 
@@ -177,7 +177,7 @@ class CLASS(HEMTT_Fuel_Base): B_Truck_01_fuel_F {
     };
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
     };
 };
 

--- a/addons/vehicles/vehicles/offroad.hpp
+++ b/addons/vehicles/vehicles/offroad.hpp
@@ -41,7 +41,7 @@ class CLASS(Offroad_Base): Offroad_01_unarmed_base_F {
     };
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
         killed = "if (local (_this select 0)) then { _this select 0 setPlateNumber '';};";
     };
 };
@@ -124,7 +124,7 @@ class CLASS(Offroad_Covered_Base): Offroad_01_military_covered_base_F {
     };
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
         killed = "if (local (_this select 0)) then { _this select 0 setPlateNumber '';};";
     };
 };
@@ -200,7 +200,7 @@ class CLASS(Offroad_Armed_Base): Offroad_01_armed_base_F {
     };
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
         killed = "if (local (_this select 0)) then { _this select 0 setPlateNumber '';};";
     };
 };

--- a/addons/vehicles/vehicles/polaris.hpp
+++ b/addons/vehicles/vehicles/polaris.hpp
@@ -41,7 +41,7 @@
         }; \
     }; \
     class EventHandlers: EventHandlers { \
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };"; \
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };"; \
     };
 
 class LSV_01_base_F;

--- a/addons/vehicles/vehicles/van.hpp
+++ b/addons/vehicles/vehicles/van.hpp
@@ -63,7 +63,7 @@ class CLASS(Van_Cargo_Base): Van_02_vehicle_base_F {
     };
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
         killed = "if (local (_this select 0)) then { _this select 0 setPlateNumber '';};";
     };
 };
@@ -159,7 +159,7 @@ class CLASS(Van_Transport_Base): Van_02_transport_base_F {
     };
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
         killed = "if (local (_this select 0)) then { _this select 0 setPlateNumber '';};";
     };
 };

--- a/addons/vehicles/vehicles/wildcat.hpp
+++ b/addons/vehicles/vehicles/wildcat.hpp
@@ -30,7 +30,7 @@ class CLASS(Heli_Wildcat_Base): I_Heli_light_03_dynamicLoadout_F {
     };
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
     };
 };
 
@@ -90,7 +90,7 @@ class CLASS(Heli_I_Wildcat_Unarmed_Base): I_Heli_light_03_unarmed_F {
     };
 
     class EventHandlers: EventHandlers {
-        init = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
     };
 };
 


### PR DESCRIPTION
- Switches `BIS_fnc_initVehicle` from `init` to `postInit`, it avoids network issues.
